### PR TITLE
scrub duped string for frozen string

### DIFF
--- a/lib/fluent/plugin/out_string_scrub.rb
+++ b/lib/fluent/plugin/out_string_scrub.rb
@@ -77,7 +77,7 @@ class Fluent::StringScrubOutput < Fluent::Output
       return string
     rescue ArgumentError => e
       raise e unless e.message.index("invalid byte sequence in") == 0
-      string.scrub!(@replace_char)
+      string = string.dup.scrub!(@replace_char)
       retry
     end
   end

--- a/lib/fluent/plugin/out_string_scrub.rb
+++ b/lib/fluent/plugin/out_string_scrub.rb
@@ -77,7 +77,11 @@ class Fluent::StringScrubOutput < Fluent::Output
       return string
     rescue ArgumentError => e
       raise e unless e.message.index("invalid byte sequence in") == 0
-      string = string.dup.scrub!(@replace_char)
+      if string.frozen?
+          string.scrub!(@replace_char)
+      else
+          string = string.dup.scrub!(@replace_char)
+      end
       retry
     end
   end

--- a/lib/fluent/plugin/out_string_scrub.rb
+++ b/lib/fluent/plugin/out_string_scrub.rb
@@ -78,9 +78,9 @@ class Fluent::StringScrubOutput < Fluent::Output
     rescue ArgumentError => e
       raise e unless e.message.index("invalid byte sequence in") == 0
       if string.frozen?
-          string.scrub!(@replace_char)
-      else
           string = string.dup.scrub!(@replace_char)
+      else
+          string.scrub!(@replace_char)
       end
       retry
     end

--- a/test/plugin/test_out_string-scrub.rb
+++ b/test/plugin/test_out_string-scrub.rb
@@ -174,4 +174,31 @@ class StringScrubOutputTest < Test::Unit::TestCase
     assert_equal "scrubbed.log", e1[0]
     assert_equal orig_message + "\uFFFD".force_encoding('UTF-8'), e1[2]['message']['message_child']
   end
+
+  def test_emit5_frozen_string
+    orig_message = 'testtesttest'
+    invalid_utf8 = "\xff".force_encoding('UTF-8')
+    d1 = create_driver(CONFIG, 'input.log')
+    d1.run do
+      d1.emit({'message' => (orig_message + invalid_utf8).freeze})
+    end
+    emits = d1.emits
+    assert_equal 1, emits.length
+    
+    e1 = emits[0]
+    assert_equal "scrubbed.log", e1[0]
+    assert_equal orig_message, e1[2]['message']
+
+    invalid_ascii = "\xff".force_encoding('US-ASCII')
+    d2 = create_driver(CONFIG, 'input.log2')
+    d2.run do
+      d2.emit({'message' => (orig_message + invalid_utf8).freeze})
+    end
+    emits = d2.emits
+    assert_equal 1, emits.length
+    
+    e2 = emits[0]
+    assert_equal "scrubbed.log2", e2[0]
+    assert_equal orig_message, e2[2]['message']
+  end
 end


### PR DESCRIPTION
to take measures against like these error
```
2015-03-23 22:19:14 +0900 [error]: forward error error=#<RuntimeError: can't modify frozen String> error_class=RuntimeError
  2015-03-23 22:19:14 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-string-scrub-0.0.3/lib/fluent/plugin/out_string_scrub.rb:80:in `scrub!'
  2015-03-23 22:19:14 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-string-scrub-0.0.3/lib/fluent/plugin/out_string_scrub.rb:80:in `rescue in with_scrub'
  2015-03-23 22:19:14 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-string-scrub-0.0.3/lib/fluent/plugin/out_string_scrub.rb:75:in `with_scrub'
  2015-03-23 22:19:14 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-string-scrub-0.0.3/lib/fluent/plugin/out_string_scrub.rb:68:in `block in recv_record'
  2015-03-23 22:19:14 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-string-scrub-0.0.3/lib/fluent/plugin/out_string_scrub.rb:64:in `each'
  2015-03-23 22:19:14 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-string-scrub-0.0.3/lib/fluent/plugin/out_string_scrub.rb:64:in `recv_record'
  2015-03-23 22:19:14 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-string-scrub-0.0.3/lib/fluent/plugin/out_string_scrub.rb:54:in `block in emit'

```