### PR TITLE
Migrate to use v1 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: ruby
 script: bundle exec rake
 sudo: false
 rvm:
-  - 2.1.*
-  - 2.2.*
-  - 2.3.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5.2
+
   #- ruby-head
 gemfile:
   - Gemfile
-  - Gemfile.fluentd.v0.12
-  - Gemfile.fluentd.v0.10
 before_install:
   - gem update bundler

--- a/Gemfile.fluentd.v0.10
+++ b/Gemfile.fluentd.v0.10
@@ -1,4 +1,0 @@
-source "http://rubygems.org"
-
-gem 'fluentd', '~> 0.10.43'
-gemspec

--- a/Gemfile.fluentd.v0.12
+++ b/Gemfile.fluentd.v0.12
@@ -1,4 +1,0 @@
-source "http://rubygems.org"
-
-gem 'fluentd', '~> 0.12.0'
-gemspec

--- a/fluent-plugin-string-scrub.gemspec
+++ b/fluent-plugin-string-scrub.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.1".freeze)
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
-  spec.add_development_dependency "fluentd"
-  spec.add_runtime_dependency "string-scrub", "~> 0.0.5" if RUBY_VERSION.to_f < 2.1
+  spec.add_development_dependency "fluentd", [">= 0.14.0", "< 2"]
 end

--- a/lib/fluent/plugin/filter_string_scrub.rb
+++ b/lib/fluent/plugin/filter_string_scrub.rb
@@ -1,11 +1,12 @@
-class Fluent::StringScrubFilter < Fluent::Filter
+require 'fluent/plugin/filter'
+
+class Fluent::Plugin::StringScrubFilter < Fluent::Plugin::Filter
   Fluent::Plugin.register_filter('string_scrub', self)
 
   config_param :replace_char, :string, :default => ''
 
   def initialize
     super
-    require 'string/scrub' if RUBY_VERSION.to_f < 2.1
   end
 
   def configure(conf)
@@ -57,4 +58,4 @@ class Fluent::StringScrubFilter < Fluent::Filter
       retry
     end
   end
-end if defined?(Fluent::Filter) # Support only >= v0.12
+end

--- a/lib/fluent/plugin/out_string_scrub.rb
+++ b/lib/fluent/plugin/out_string_scrub.rb
@@ -1,19 +1,17 @@
-class Fluent::StringScrubOutput < Fluent::Output
+require 'fluent/plugin/output'
+
+class Fluent::Plugin::StringScrubOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('string_scrub', self)
+
+  helpers :event_emitter
 
   config_param :tag, :string, :default => nil
   config_param :remove_prefix, :string, :default => nil
   config_param :add_prefix, :string, :default => nil
   config_param :replace_char, :string, :default => ''
 
-  # Define `router` method of v0.12 to support v0.10 or earlier
-  unless method_defined?(:router)
-    define_method("router") { Fluent::Engine }
-  end
-
   def initialize
     super
-    require 'string/scrub' if RUBY_VERSION.to_f < 2.1
   end
 
   def configure(conf)
@@ -40,7 +38,7 @@ class Fluent::StringScrubOutput < Fluent::Output
     end
   end
 
-  def emit(tag, es, chain)
+  def process(tag, es)
     tag = if @tag
             @tag
           else
@@ -63,8 +61,6 @@ class Fluent::StringScrubOutput < Fluent::Output
       next if scrubbed.nil?
       router.emit(tag, time, scrubbed)
     end
-
-    chain.next
   end
 
   def recv_record(record)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,16 +13,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
 require 'fluent/version'
-unless ENV.has_key?('VERBOSE')
-  nulllogger = Object.new
-  nulllogger.instance_eval {|obj|
-    def method_missing(method, *args)
-      # pass
-    end
-  }
-  $log = nulllogger
-end
-
+require 'fluent/test/driver/output'
+require 'fluent/test/driver/filter'
 require 'fluent/plugin/out_string_scrub'
 require 'fluent/plugin/filter_string_scrub'
 

--- a/test/plugin/test_filter_string-scrub.rb
+++ b/test/plugin/test_filter_string-scrub.rb
@@ -20,24 +20,22 @@ class StringScrubFilterTest < Test::Unit::TestCase
     replace_char \u{FFFD}
   ]
 
-  def create_driver(conf=CONFIG, tag='test.filter')
-    Fluent::Test::FilterTestDriver.new(Fluent::StringScrubFilter).configure(conf, tag)
+  def create_driver(conf=CONFIG)
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::StringScrubFilter).configure(conf)
   end
 
   def filter(config, msgs)
     d = create_driver(config)
-    d.run {
+    d.run(default_tag: 'test.filter') {
       msgs.each {|msg|
-        d.filter(msg, @time)
+        d.feed(@time, msg)
       }
     }
-    filtered = d.filtered_as_array
-    filtered.map {|m| m[2] }
+    filtered = d.filtered
+    filtered.map {|m| m[1] }
   end
 
   def test_filter1
-    return unless defined? Fluent::Filter
-
     orig_message = 'testtesttest'
     invalid_utf8 = "\xff".force_encoding('UTF-8')
     msg = {"message" => orig_message + invalid_utf8}

--- a/test/plugin/test_out_string-scrub.rb
+++ b/test/plugin/test_out_string-scrub.rb
@@ -28,8 +28,8 @@ class StringScrubOutputTest < Test::Unit::TestCase
     replace_char \u{FFFD}
   ]
 
-  def create_driver(conf = CONFIG, tag = 'test', use_v1_config = true)
-    Fluent::Test::OutputTestDriver.new(Fluent::StringScrubOutput, tag).configure(conf, use_v1_config)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::StringScrubOutput).configure(conf)
   end
 
   def test_configure
@@ -78,48 +78,28 @@ class StringScrubOutputTest < Test::Unit::TestCase
     }
   end
 
-  def test_emit_fluentd_0_12
-    if Fluent::VERSION >= "0.12"
-      in_tag = 'input.log'
-      orig_message = 'testtesttest'
-      Fluent::Engine.root_agent.add_label('@foo')
-      d = create_driver(%[
-                        @label @foo
-                        ], in_tag)
-      label = Fluent::Engine.root_agent.find_label('@foo')
-      assert_equal(label.event_router, d.instance.router)
-
-      d.run do
-        d.emit({'message' => orig_message})
-      end
-      emits = d.emits
-      tag, time, record = emits.first
-      assert_equal(in_tag, tag)
-    end
-  end
-
   def test_emit1_invalid_string
     orig_message = 'testtesttest'
     invalid_utf8 = "\xff".force_encoding('UTF-8')
-    d1 = create_driver(CONFIG, 'input.log')
-    d1.run do
-      d1.emit({'message' => orig_message + invalid_utf8})
+    d1 = create_driver(CONFIG)
+    d1.run(default_tag: 'input.log') do
+      d1.feed({'message' => orig_message + invalid_utf8})
     end
-    emits = d1.emits
+    emits = d1.events
     assert_equal 1, emits.length
-    
+
     e1 = emits[0]
     assert_equal "scrubbed.log", e1[0]
     assert_equal orig_message, e1[2]['message']
 
     invalid_ascii = "\xff".force_encoding('US-ASCII')
-    d2 = create_driver(CONFIG, 'input.log2')
-    d2.run do
-      d2.emit({'message' => orig_message + invalid_utf8})
+    d2 = create_driver(CONFIG)
+    d2.run(default_tag: 'input.log2') do
+      d2.feed({'message' => orig_message + invalid_utf8})
     end
-    emits = d2.emits
+    emits = d2.events
     assert_equal 1, emits.length
-    
+
     e2 = emits[0]
     assert_equal "scrubbed.log2", e2[0]
     assert_equal orig_message, e2[2]['message']
@@ -128,11 +108,11 @@ class StringScrubOutputTest < Test::Unit::TestCase
   def test_emit2_replace_char
     orig_message = 'testtesttest'
     invalid_utf8 = "\xff".force_encoding('UTF-8')
-    d1 = create_driver(CONFIG_REPLACE_CHAR, 'input.log')
-    d1.run do
-      d1.emit({'message' => orig_message + invalid_utf8})
+    d1 = create_driver(CONFIG_REPLACE_CHAR)
+    d1.run(default_tag: 'input.log') do
+      d1.feed({'message' => orig_message + invalid_utf8})
     end
-    emits = d1.emits
+    emits = d1.events
     assert_equal 1, emits.length
 
     e1 = emits[0]
@@ -140,11 +120,11 @@ class StringScrubOutputTest < Test::Unit::TestCase
     assert_equal orig_message + '?', e1[2]['message']
 
     invalid_ascii = "\xff".force_encoding('US-ASCII')
-    d2 = create_driver(CONFIG_REPLACE_CHAR, 'input.log2')
-    d2.run do
-        d2.emit({'message' => orig_message + invalid_utf8})
+    d2 = create_driver(CONFIG_REPLACE_CHAR)
+    d2.run(default_tag: 'input.log2') do
+        d2.feed({'message' => orig_message + invalid_utf8})
     end
-    emits = d2.emits
+    emits = d2.events
     assert_equal 1, emits.length
 
     e2 = emits[0]
@@ -155,11 +135,11 @@ class StringScrubOutputTest < Test::Unit::TestCase
   def test_emit3_struct_message
     orig_message = 'testtesttest'
     invalid_utf8 = "\xff".force_encoding('UTF-8')
-    d1 = create_driver(CONFIG_REPLACE_CHAR, 'input.log')
-    d1.run do
-      d1.emit({'message' => {'message_child' => orig_message + invalid_utf8}})
+    d1 = create_driver(CONFIG_REPLACE_CHAR)
+    d1.run(default_tag: 'input.log') do
+      d1.feed({'message' => {'message_child' => orig_message + invalid_utf8}})
     end
-    emits = d1.emits
+    emits = d1.events
     assert_equal 1, emits.length
 
     e1 = emits[0]
@@ -170,11 +150,11 @@ class StringScrubOutputTest < Test::Unit::TestCase
   def test_emit4_unicode1
     orig_message = 'testtesttest'
     invalid_utf8 = "\xff".force_encoding('UTF-8')
-    d1 = create_driver(CONFIG_UNICODE_1, 'input.log')
-    d1.run do
-      d1.emit({'message' => {'message_child' => orig_message + invalid_utf8}})
+    d1 = create_driver(CONFIG_UNICODE_1)
+    d1.run(default_tag: 'input.log') do
+      d1.feed({'message' => {'message_child' => orig_message + invalid_utf8}})
     end
-    emits = d1.emits
+    emits = d1.events
     assert_equal 1, emits.length
 
     e1 = emits[0]
@@ -183,11 +163,11 @@ class StringScrubOutputTest < Test::Unit::TestCase
 
     orig_message = 'testtesttest'
     invalid_utf8 = "\xff".force_encoding('UTF-8')
-    d1 = create_driver(CONFIG_UNICODE_2, 'input.log')
-    d1.run do
-      d1.emit({'message' => {'message_child' => orig_message + invalid_utf8}})
+    d1 = create_driver(CONFIG_UNICODE_2)
+    d1.run(default_tag: 'input.log') do
+      d1.feed({'message' => {'message_child' => orig_message + invalid_utf8}})
     end
-    emits = d1.emits
+    emits = d1.events
     assert_equal 1, emits.length
 
     e1 = emits[0]
@@ -198,25 +178,25 @@ class StringScrubOutputTest < Test::Unit::TestCase
   def test_emit5_frozen_string
     orig_message = 'testtesttest'
     invalid_utf8 = "\xff".force_encoding('UTF-8')
-    d1 = create_driver(CONFIG, 'input.log')
-    d1.run do
-      d1.emit({'message' => (orig_message + invalid_utf8).freeze})
+    d1 = create_driver(CONFIG)
+    d1.run(default_tag: 'input.log') do
+      d1.feed({'message' => (orig_message + invalid_utf8).freeze})
     end
-    emits = d1.emits
+    emits = d1.events
     assert_equal 1, emits.length
-    
+
     e1 = emits[0]
     assert_equal "scrubbed.log", e1[0]
     assert_equal orig_message, e1[2]['message']
 
     invalid_ascii = "\xff".force_encoding('US-ASCII')
-    d2 = create_driver(CONFIG, 'input.log2')
-    d2.run do
-      d2.emit({'message' => (orig_message + invalid_utf8).freeze})
+    d2 = create_driver(CONFIG)
+    d2.run(default_tag: 'input.log2') do
+      d2.feed({'message' => (orig_message + invalid_utf8).freeze})
     end
-    emits = d2.emits
+    emits = d2.events
     assert_equal 1, emits.length
-    
+
     e2 = emits[0]
     assert_equal "scrubbed.log2", e2[0]
     assert_equal orig_message, e2[2]['message']


### PR DESCRIPTION
Using with Fluentd v1 is preferred to migrate the brand new Fluentd v1 API.
It does not have backward compatibility but it provides multi processes, workable on Windows, elastic driver APIs feature.