### PR TITLE
Fix integer regex deprecation warnings for Ruby 2.6.0 or later

### DIFF
--- a/lib/fluent/plugin/filter_string_scrub.rb
+++ b/lib/fluent/plugin/filter_string_scrub.rb
@@ -37,6 +37,8 @@ class Fluent::Plugin::StringScrubFilter < Fluent::Plugin::Filter
     record.each do |k,v|
       if v.instance_of? Hash
         scrubbed[with_scrub(k)] = recv_record(v)
+      elsif v.instance_of? Integer
+        scrubbed[k] = v
       else
         scrubbed[with_scrub(k)] = with_scrub(v)
       end

--- a/lib/fluent/plugin/out_string_scrub.rb
+++ b/lib/fluent/plugin/out_string_scrub.rb
@@ -68,6 +68,8 @@ class Fluent::Plugin::StringScrubOutput < Fluent::Plugin::Output
     record.each do |k,v|
       if v.instance_of? Hash
         scrubbed[with_scrub(k)] = recv_record(v)
+      elsif v.instance_of? Integer
+        scrubbed[k] = v
       else
         scrubbed[with_scrub(k)] = with_scrub(v)
       end

--- a/test/plugin/test_filter_string-scrub.rb
+++ b/test/plugin/test_filter_string-scrub.rb
@@ -43,4 +43,10 @@ class StringScrubFilterTest < Test::Unit::TestCase
     assert_equal([{"message" => orig_message + '?'}], filtered)
   end
 
+  def test_filter_integer
+    orig_message = 123456789
+    msg = {"message" => orig_message}
+    filtered = filter(CONFIG, [msg])
+    assert_equal([{"message" => orig_message}], filtered)
+  end
 end

--- a/test/plugin/test_out_string-scrub.rb
+++ b/test/plugin/test_out_string-scrub.rb
@@ -201,4 +201,18 @@ class StringScrubOutputTest < Test::Unit::TestCase
     assert_equal "scrubbed.log2", e2[0]
     assert_equal orig_message, e2[2]['message']
   end
+
+  def test_emit6_integer
+    orig_message = 123456789
+    d1 = create_driver(CONFIG)
+    d1.run(default_tag: 'input.log') do
+      d1.feed({'message' => orig_message})
+    end
+    emits = d1.events
+    assert_equal 1, emits.length
+
+    e1 = emits[0]
+    assert_equal "scrubbed.log", e1[0]
+    assert_equal orig_message, e1[2]['message']
+  end
 end


### PR DESCRIPTION
Since Ruby 2.6.0, when I try to match a regular expression against Interger, I get a warning message.
So we changed it so that Integer is not scrubbed.

```
/usr/lib/ruby/gems/2.7.0/gems/fluent-plugin-string-scrub-1.0.0/lib/fluent/plugin/filter_string_scrub.rb:49: warning: deprecated Object#=~ is called on Integer; it always returns nil
```
