### PR TITLE
filter_string_scrub: use the new filter API

### DIFF
--- a/lib/fluent/plugin/filter_string_scrub.rb
+++ b/lib/fluent/plugin/filter_string_scrub.rb
@@ -17,24 +17,13 @@ class Fluent::Plugin::StringScrubFilter < Fluent::Plugin::Filter
     end
   end
 
-  def filter_stream(tag, es)
-    new_es = Fluent::MultiEventStream.new
-    es.each do |time,record|
-      begin
-        scrubbed = recv_record(record)
-        next if scrubbed.nil?
-        new_es.add(time, scrubbed)
-      rescue => e
-        router.emit_error_event(tag, time, record, e)
-      end
-    end
-
-    new_es
+  def filter(_tag, _time, record)
+    recv_record(record)
   end
 
   def recv_record(record)
     scrubbed = {}
-    record.each do |k,v|
+    record.each do |k, v|
       if v.instance_of? Hash
         scrubbed[with_scrub(k)] = recv_record(v)
       elsif v.instance_of? Integer


### PR DESCRIPTION
Use the new `filter` API instead of `filter_stream`. Usage of the `filter_stream` API disables some optimizations as per the docs and logs:

```
disable filter chain optimization because [Fluent::Plugin::StringScrubFilter] uses `#filter_stream` method.
```

Docs: https://docs.fluentd.org/filter#filter-chain-optimization.

This new API has been implemented in ~2017 so I think it's safe to just switch to it.

Tests pass without any change:
```
Loaded suite /home/giedrius/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
.........
Finished in 0.052871143 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
9 tests, 40 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
170.23 tests/s, 756.56 assertions/s
```