### PR TITLE
Fix the bug that treats non-string as string

### DIFF
--- a/fluent-plugin-string-scrub.gemspec
+++ b/fluent-plugin-string-scrub.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-string-scrub"
-  spec.version       = "1.0.1"
+  spec.version       = "1.0.2"
   spec.authors       = ["Noriaki Katayama"]
   spec.email         = ["kataring@gmail.com"]
   spec.summary       = %q{Fluentd Output filter plugin.}

--- a/lib/fluent/plugin/filter_string_scrub.rb
+++ b/lib/fluent/plugin/filter_string_scrub.rb
@@ -26,10 +26,10 @@ class Fluent::Plugin::StringScrubFilter < Fluent::Plugin::Filter
     record.each do |k, v|
       if v.instance_of? Hash
         scrubbed[with_scrub(k)] = recv_record(v)
-      elsif v.instance_of? Integer
-        scrubbed[k] = v
-      else
+      elsif v.instance_of? String
         scrubbed[with_scrub(k)] = with_scrub(v)
+      else
+        scrubbed[with_scrub(k)] = v
       end
     end
     scrubbed


### PR DESCRIPTION
Fixes the issue https://github.com/kataring/fluent-plugin-string-scrub/issues/17 where we try to process non-string value and that will fail.

Test
 - Test in a local env and observed no failure before the fix and the logs getting forwarded correctly in our scenario of using fluentd as a log forwarder.